### PR TITLE
Update GSD-2022-1000007.json

### DIFF
--- a/2022/1000xxx/GSD-2022-1000007.json
+++ b/2022/1000xxx/GSD-2022-1000007.json
@@ -39,13 +39,13 @@
     "affected": [
       {
         "package": {
-          "name": "color.js",
+          "name": "colors",
           "ecosystem": "JavaScript"
         },
         "ranges": [
           {
             "type": "GIT",
-            "repo": "https://github.com/Marak/colors.js/c",
+            "repo": "https://github.com/Marak/colors.js",
             "events": [
               {
                 "introduced": "074a0f8ed0c31c35d13d28632bd8a049ff136fb6"


### PR DESCRIPTION
Shouldn't it be something like this?
Since `color.js` npm package has actually no affiliation with `colors` (the affected) npm package.