### PR TITLE
Update GSD-2022-1000007.json

### DIFF
--- a/2022/1000xxx/GSD-2022-1000007.json
+++ b/2022/1000xxx/GSD-2022-1000007.json
@@ -1,10 +1,10 @@
 {
   "GSD": {
-    "vendor_name": "color.js",
-    "product_name": "color.js",
+    "vendor_name": "colors.js",
+    "product_name": "colors.js",
     "product_version": "version 1.4.1",
     "vulnerability_type": "infinite loop",
-    "affected_component": "color.js",
+    "affected_component": "colors.js",
     "attack_vector": "unspecified",
     "impact": "Denial-of-Service",
     "credit": "",
@@ -34,18 +34,18 @@
     "reporter": "kurtseifried",
     "reporter_id": 582211,
     "notes": "",
-    "description": "color.js had an infinite loop added by the primary developer in version 1.4.1 and 6.6.6 which was released on GitHub and NPM (which reports it as having 3,179 dependent packages that rely upon it). Additionally the GitHub repo was wiped of all files. This appears to have been done intentionally in commit 074a0f8ed0c31c35d13d28632bd8a049ff136fb6. It has since been fixed and color.js version 1.4.2 has been released and it appears that both GitHub and NPM have locked out the original developer account and reverted the changes. Please note that this issue is directly related to GSD-2022-1000008 and appears to be part of the same incident."
+    "description": "colors.js had an infinite loop added by the primary developer in version 1.4.1 and 6.6.6 which was released on GitHub and NPM (which reports it as having 3,179 dependent packages that rely upon it). Additionally the GitHub repo was wiped of all files. This appears to have been done intentionally in commit 074a0f8ed0c31c35d13d28632bd8a049ff136fb6. It has since been fixed and colors.js version 1.4.2 has been released and it appears that both GitHub and NPM have locked out the original developer account and reverted the changes. Please note that this issue is directly related to GSD-2022-1000008 and appears to be part of the same incident."
   },
   "OSV": {
     "id": "GSD-2022-1000007",
     "modified": "2022-01-09T11:37:01.199689Z",
     "published": "2022-01-09T02:46:05.199689Z",
-    "summary": "color.js 1.4.1 has an infinite loop added by the primary developer",
-    "details": "color.js had an infinite loop added by the primary developer in version 1.4.1 and 6.6.6 which was released on GitHub and NPM (which reports it as having 3,179 dependent packages that rely upon it). Additionally the GitHub repo was wiped of all files. This appears to have been done intentionally in commit 074a0f8ed0c31c35d13d28632bd8a049ff136fb6. It has since been fixed and color.js version 1.4.2 has been released and it appears that both GitHub and NPM have locked out the original developer account and reverted the changes. Please note that this issue is directly related to GSD-2022-1000008 and appears to be part of the same incident.",
+    "summary": "colors.js 1.4.1 has an infinite loop added by the primary developer",
+    "details": "colors.js had an infinite loop added by the primary developer in version 1.4.1 and 6.6.6 which was released on GitHub and NPM (which reports it as having 3,179 dependent packages that rely upon it). Additionally the GitHub repo was wiped of all files. This appears to have been done intentionally in commit 074a0f8ed0c31c35d13d28632bd8a049ff136fb6. It has since been fixed and colors.js version 1.4.2 has been released and it appears that both GitHub and NPM have locked out the original developer account and reverted the changes. Please note that this issue is directly related to GSD-2022-1000008 and appears to be part of the same incident.",
     "affected": [
       {
         "package": {
-          "name": "color.js",
+          "name": "colors.js",
           "ecosystem": "JavaScript"
         },
         "ranges": [


### PR DESCRIPTION
looks like the name is still wrong - it should be colors.js and not color.js as color.js is a different package and not affected.