### PR TITLE
Removed .GSD.namespaces."nvd.nist.gov".configurations

### DIFF
--- a/2022/22xxx/GSD-2022-22704.json
+++ b/2022/22xxx/GSD-2022-22704.json
@@ -2,50 +2,7 @@
     "GSD": {
         "alias": "CVE-2022-22704",
         "description": "The zabbix-agent2 package before 5.4.9-r1 for Alpine Linux sometimes allows privilege escalation to root because the design incorrectly expected that systemd would (in effect) determine part of the configuration.",
-        "id": "GSD-2022-22704",
-        "namespaces": {
-            "nvd.nist.gov": {
-                "configurations": {
-                    "CVE_data_version": "4.0",
-                    "nodes": [
-                        {
-                            "children": [
-                                {
-                                    "children": [],
-                                    "cpe_match": [
-                                        {
-                                            "cpe23Uri": "cpe:2.3:a:zabbix:zabbix-agent2:*:*:*:*:*:*:*:*",
-                                            "cpe_name": [],
-                                            "versionEndExcluding": "5.4.9",
-                                            "vulnerable": true
-                                        },
-                                        {
-                                            "cpe23Uri": "cpe:2.3:a:zabbix:zabbix-agent2:5.4.9:-:*:*:*:*:*:*",
-                                            "cpe_name": [],
-                                            "vulnerable": true
-                                        }
-                                    ],
-                                    "operator": "OR"
-                                },
-                                {
-                                    "children": [],
-                                    "cpe_match": [
-                                        {
-                                            "cpe23Uri": "cpe:2.3:o:alpinelinux:alpine_linux:-:*:*:*:*:*:*:*",
-                                            "cpe_name": [],
-                                            "vulnerable": false
-                                        }
-                                    ],
-                                    "operator": "OR"
-                                }
-                            ],
-                            "cpe_match": [],
-                            "operator": "AND"
-                        }
-                    ]
-                }
-            }
-        }
+        "id": "GSD-2022-22704"
     },
     "namespaces": {
         "cve.org": {


### PR DESCRIPTION
`.GSD.namespaces."nvd.nist.gov".configurations` in GSD-2022-22704 was a duplicate of `.namespaces."nvd.nist.gov.configurations"`.
This must have been a copy and paste error.

With this commit the object under `.GSD.namespaces."nvd.nist.gov".configurations` was removed.