### PR TITLE
Fixed broken Debian CVEs

### DIFF
--- a/2001/0xxx/GSD-2001-0191.json
+++ b/2001/0xxx/GSD-2001-0191.json
@@ -5,7 +5,8 @@
         "id": "GSD-2001-0191",
         "references": [
             "https://access.redhat.com/errata/RHSA-2001:011",
-            "https://access.redhat.com/errata/RHSA-2001:010"
+            "https://access.redhat.com/errata/RHSA-2001:010",
+            "https://www.debian.org/security/2001/dsa-042"
         ]
     },
     "namespaces": {

--- a/2001/xxx/GSD-2001-191.json
+++ b/2001/xxx/GSD-2001-191.json
@@ -1,9 +1,0 @@
-{
-    "GSD": {
-        "alias": "CVE-2001-191",
-        "id": "GSD-2001-191",
-        "references": [
-            "https://www.debian.org/security/2001/dsa-042"
-        ]
-    }
-}

--- a/2002/0xxx/GSD-2002-0012.json
+++ b/2002/0xxx/GSD-2002-0012.json
@@ -6,7 +6,8 @@
         "references": [
             "https://access.redhat.com/errata/RHSA-2002:088",
             "https://access.redhat.com/errata/RHSA-2002:036",
-            "https://access.redhat.com/errata/RHSA-2001:163"
+            "https://access.redhat.com/errata/RHSA-2001:163",
+            "https://www.debian.org/security/2002/dsa-111"
         ]
     },
     "namespaces": {

--- a/2002/0xxx/GSD-2002-0013.json
+++ b/2002/0xxx/GSD-2002-0013.json
@@ -6,7 +6,8 @@
         "references": [
             "https://access.redhat.com/errata/RHSA-2002:088",
             "https://access.redhat.com/errata/RHSA-2002:036",
-            "https://access.redhat.com/errata/RHSA-2001:163"
+            "https://access.redhat.com/errata/RHSA-2001:163",
+            "https://www.debian.org/security/2002/dsa-111"
         ]
     },
     "namespaces": {

--- a/2002/xxx/GSD-2002-012.json
+++ b/2002/xxx/GSD-2002-012.json
@@ -1,9 +1,0 @@
-{
-    "GSD": {
-        "alias": "CVE-2002-012",
-        "id": "GSD-2002-012",
-        "references": [
-            "https://www.debian.org/security/2002/dsa-111"
-        ]
-    }
-}

--- a/2002/xxx/GSD-2002-013.json
+++ b/2002/xxx/GSD-2002-013.json
@@ -1,9 +1,0 @@
-{
-    "GSD": {
-        "alias": "CVE-2002-013",
-        "id": "GSD-2002-013",
-        "references": [
-            "https://www.debian.org/security/2002/dsa-111"
-        ]
-    }
-}


### PR DESCRIPTION
https://www.debian.org/security/2002/dsa-111
Security database references:
In Mitre's CVE dictionary: [CVE-2002-012](https://security-tracker.debian.org/tracker/CVE-2002-012), [CVE-2002-013](https://security-tracker.debian.org/tracker/CVE-2002-013).


https://www.debian.org/security/2001/dsa-042
Security database references:
In the Bugtraq database (at SecurityFocus): [BugTraq ID 2333](http://online.securityfocus.com/bid/2333).
In Mitre's CVE dictionary: [CVE-2001-191](https://security-tracker.debian.org/tracker/CVE-2001-191).