### PR TITLE
Fixed the regex to filter json files

### DIFF
--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -16,6 +16,7 @@ jobs:
       - name: json-check
         run: |
           echo "Listing Changed JSON Files"
-          FILES=$(git diff --name-only origin/main HEAD | grep "json")
+          FILES=$(git diff --name-only origin/main HEAD | grep '\.json$' || true)
           echo "$FILES"
+          [[ -z "$FILES" ]] && exit 0
           echo "$FILES" | xargs -n1 -I {} python -m json.tool {}


### PR DESCRIPTION
The regex triggers for `.github/workflows/json.yml` as well.

See https://github.com/cloudsecurityalliance/gsd-database/runs/5577292233?check_suite_focus=true