### PR TITLE
specify rust as target software component in CPE

### DIFF
--- a/2018/20xxx/GSD-2018-20998.json
+++ b/2018/20xxx/GSD-2018-20998.json
@@ -2,7 +2,28 @@
     "GSD": {
         "alias": "CVE-2018-20998",
         "description": "An issue was discovered in the arrayfire crate before 3.6.0 for Rust. Addition of the repr() attribute to an enum is mishandled, leading to memory corruption.",
-        "id": "GSD-2018-20998"
+        "id": "GSD-2018-20998",
+        "namespaces": {
+            "nvd.nist.gov": {
+                "configurations": {
+                    "CVE_data_version": "4.0",
+                    "nodes": [
+                        {
+                            "children": [],
+                            "cpe_match": [
+                                {
+                                    "cpe23Uri": "cpe:2.3:a:arrayfire:arrayfire:*:*:*:*:*:rust:*:*",
+                                    "cpe_name": [],
+                                    "versionEndExcluding": "3.6.0",
+                                    "vulnerable": true
+                                }
+                            ],
+                            "operator": "OR"
+                        }
+                    ]
+                }
+            }
+        }
     },
     "namespaces": {
         "cve.org": {


### PR DESCRIPTION
This is specifically a vulnerability that applies to the arrayfire rust bindings which should be distinguished from bindings for other ecosystems to help prevent mismatches like with https://github.com/pypa/advisory-database/pull/99

Signed-off-by: Weston Steimel <weston.steimel@anchore.com>