### PR TITLE
fix: use correct ecosystem for GSD-2022-1000008

### DIFF
--- a/2022/1000xxx/GSD-2022-1000008.json
+++ b/2022/1000xxx/GSD-2022-1000008.json
@@ -41,7 +41,7 @@
       {
         "package": {
           "name": "faker.js",
-          "ecosystem": "JavaScript"
+          "ecosystem": "npm"
         }
       }
     ]


### PR DESCRIPTION
According to the OSV specification `npm` is the correct ecosystem to be using.

Currently this is creating a dedicated bullet on https://osv.dev/list 😂 

![image](https://user-images.githubusercontent.com/3151613/193438593-e2151834-9e5b-4e00-bb35-60301c5f1d99.png)
